### PR TITLE
4341 - Remove Hazard Flashers from config

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -291,38 +291,6 @@ esb_xml_send_signs_markings:
   job: true
   path: ../transportation-data-publishing/transportation-data-publishing/data_tracker
   source: knack
-hazard_flashers_agol:
-  args:
-    - hazard_flashers
-    - data_tracker_prod
-    - -d
-    - agol
-    - --last_run_date
-    - "0"
-  cron: 15 3 * * *
-  destination: agol
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
-hazard_flashers_socrata:
-  args:
-    - hazard_flashers
-    - data_tracker_prod
-    - -d
-    - socrata
-    - --last_run_date
-    - "0"
-  cron: 15 3 * * *
-  destination: socrata
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
 kits_cctv_push:
   cron: 25 * * * *
   destination: kits


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/atd-data-tech/issues/4341
Removes the hazard flashers from config.yml

Here is the corresponding airflow PR: https://github.com/cityofaustin/atd-airflow/pull/49
Corresponding atd-knack-services PR: https://github.com/cityofaustin/atd-knack-services/pull/68

socrata: https://data.austintexas.gov/Transportation-and-Mobility/Flashing-Beacons/wczq-5cer
agol: https://austin.maps.arcgis.com/home/item.html?id=6c4392540b684d598c72e52206d774be#overview