### PR TITLE
4961 - remove knack detectors from config

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -72,38 +72,6 @@ detection_status_signals:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/data_tracker
   source: knack
-detectors_agol:
-  args:
-    - detectors
-    - data_tracker_prod
-    - -d
-    - agol
-    - --last_run_date
-    - "0"
-  cron: 10 2 * * *
-  destination: agol
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
-detectors_socrata:
-  args:
-    - detectors
-    - data_tracker_prod
-    - -d
-    - socrata
-    - --last_run_date
-    - "0"
-  cron: 10 2 * * *
-  destination: socrata
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
 device_status_cameras_cell_modem:
   args:
     - cameras_cell_modem


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/4961

Removes the `detectors_agol` and `detectors_socrata` processes

Here is the corresponding airflow PR: https://github.com/cityofaustin/atd-airflow/pull/50/
Corresponding atd-knack-services PR: 

**socrata:** https://data.austintexas.gov/Transportation-and-Mobility/Traffic-Detectors/qpuw-8eeb
**agol:** https://austin.maps.arcgis.com/home/item.html?id=47d17ff3ce664849a16b9974979cd12e
**knack:** https://atd.knack.com/amd#signal-queries/signal-detectors-api/
