### PR TITLE
5814 - remove travel sensors processes

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -526,38 +526,6 @@ traffic_study_locations:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/traffic_study
   source: agol
-travel_sensors_agol:
-  args:
-    - travel_sensors
-    - data_tracker_prod
-    - -d
-    - agol
-    - --last_run_date
-    - "0"
-  cron: 15 2 * * *
-  destination: agol
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
-travel_sensors_socrata:
-  args:
-    - travel_sensors
-    - data_tracker_prod
-    - -d
-    - socrata
-    - --last_run_date
-    - "0"
-  cron: 15 2 * * *
-  destination: socrata
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
 visitor_log_socrata:
   args:
     - atd_visitor_log


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/5814

Removes the travel_sensors_agol and travel_sensors_socrata processes

Here is the corresponding airflow PR: cityofaustin/atd-airflow#51
Corresponding atd-knack-services PR: https://github.com/cityofaustin/atd-knack-services/pull/70

**socrata:** https://data.austintexas.gov/Transportation-and-Mobility/Travel-Sensors/6yd9-yz2
**agol:** https://austin.maps.arcgis.com/home/item.html?id=9776d3e894a74521a7f63443f7becc7c
**knack:** https://atd.knack.com/amd#signal-queries/travel-sensors/
