### PR TITLE
4963 - remove process for pole attachments

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -279,40 +279,6 @@ location_updater:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/data_tracker
   source: knack
-pole_attachments_agol:
-  args:
-    - pole_attachments
-    - data_tracker_prod
-    - -d
-    - agol
-    - --replace
-    - --last_run_date
-    - "0"
-  cron: 35 6 * * *
-  destination: agol
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
-pole_attachments_socrata:
-  args:
-    - pole_attachments
-    - data_tracker_prod
-    - -d
-    - socrata
-    - --replace
-    - --last_run_date
-    - "0"
-  cron: 36 6 * * *
-  destination: socrata
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
 radar_count_pub:
   cron: 5-59/15 * * * *
   destination: socrata


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/4963

Removes process for pole attachments

Here is the corresponding atd-knack-services PR: https://github.com/cityofaustin/atd-knack-services/pull/72
Corresponding atd-airflow PR: https://github.com/cityofaustin/atd-airflow/pull/53

**socrata:** https://data.austintexas.gov/dataset/Pole-Attachments/btg5-ebcy
**agol:** https://austin.maps.arcgis.com/home/item.html?id=3a5a777f780447db940534b5808d4ba7
**knack:** https://atd.knack.com/amd#pole-attachments2/