### PR TITLE
Remove traffic reports and street seg updater from config

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -234,19 +234,6 @@ signal_requests:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/open_data
   source: knack
-street_seg_updater:
-  args:
-    - data_tracker_prod
-    - --last_run_date
-    - 0
-  cron: 45 * * * *
-  destination: knack
-  enabled: true
-  filename: street_seg_updater.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/data_tracker
-  source: knack
 timed_corridors:
   args:
     - timed_corridors
@@ -267,15 +254,6 @@ timed_corridors:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/open_data
   source: knack
-traffic_reports:
-  cron: "*/5 * * * *"
-  destination: postgrest
-  enabled: true
-  filename: traffic_reports.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/data_tracker
-  source: rss
 traffic_reports_pub:
   args:
     - traffic_reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ arrow
 atd-email-util
 atd-jobs-util
 atd-log-util
-pyaml
+pyaml==5.4.1


### PR DESCRIPTION
Removed two of the config entries that have been migrated to prefect. 

I've already gone in and manually commented out the cron entries in the crontab for these two ETLs. 

It's been a while but I remembered before the way I'd update the crontab was to delete all the entries that were below "# Crontab entries generated by python-docker-cron" and then did a sudo git pull of this repo and it automatically updated the crontab. But I tried that recently and it didn't work as I remembered. 

Do I need to instead run `python build.py` ? I'm also looking for where to update the entries in the publisher postgrest (https://github.com/cityofaustin/atd-data-and-performance/blob/production/pages/publisher.js#L24)